### PR TITLE
Fix peer sync bug

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   yorkie:
     volumes:
     - ./yorkie.json:/app/yorkie.json
-    image: 'yorkieteam/yorkie:0.1.0'
+    image: 'yorkieteam/yorkie:latest'
     container_name: 'yorkie'
     command: ["/app/bin/yorkie", "agent", "-c", "/app/yorkie.json"]
     restart: always

--- a/src/hooks/usePeer.ts
+++ b/src/hooks/usePeer.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/indent */
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { AppState } from 'app/rootReducer';
@@ -9,16 +10,18 @@ export default function usePeer() {
   const client = useSelector((state: AppState) => state.docState.client);
   const peers = useSelector((state: AppState) => state.peerState.peers);
 
-  const activePeers = client
-    ? Object.entries(peers)
-        .filter(([clientId, clientInfo]) => {
-          if (client.getID() === clientId) {
-            return false;
-          }
-          return clientInfo.status === ConnectionStatus.Connected;
-        })
-        .map(([_, clientInfo]) => clientInfo)
-    : [];
+  const activePeers = useMemo(() => {
+    return client
+      ? Object.entries(peers)
+          .filter(([clientId, clientInfo]) => {
+            if (client.getID() === clientId) {
+              return false;
+            }
+            return clientInfo.status === ConnectionStatus.Connected;
+          })
+          .map(([_, clientInfo]) => clientInfo)
+      : [];
+  }, [client, peers]);
 
   return { activePeers };
 }


### PR DESCRIPTION
#### What does this PR do?

There are cases where the user does not receive `peer-event` when accessing

Thus, the time of document and client creation and server synchronization is divided.

After creating client and document, execute `client.subscribe` and then synchronize with server

as-is

create client,document and  sync server -> subscribe

to-be

create client,document -> subscribe -> sync server

#### Any background context you want to provide?

#### What are the relevant tickets?

Fixes #

### Checklist

- [ ] Added relevant tests
- [ ] Didn't break anything
