### PR TITLE
Reduce the value of the stored points by applying the douglas-peucker-algorithm

### DIFF
--- a/src/components/Editor/Board/Canvas/Container.ts
+++ b/src/components/Editor/Board/Canvas/Container.ts
@@ -2,7 +2,7 @@ import { Tool } from 'features/boardSlices';
 import Canvas from './Canvas';
 
 import { Root, Point, Line, Shapes, Shape, TimeTicket } from './Shape';
-import { drawLine, createLine } from './utils';
+import { drawLine, createLine, compressPoints } from './utils';
 import * as schedule from './schedule';
 
 interface Options {
@@ -104,7 +104,7 @@ export default class Container {
           const points = tasks.map((task) => task.point);
           const lastShape = root.shapes.getElementByID(this.createId) as Line;
 
-          lastShape.points.push(...points);
+          lastShape.points.push(...compressPoints(points));
           this.drawAll(root.shapes);
         }
       });

--- a/src/components/Editor/Board/Canvas/Container.ts
+++ b/src/components/Editor/Board/Canvas/Container.ts
@@ -3,6 +3,7 @@ import Canvas from './Canvas';
 
 import { Root, Point, Line, Shapes, Shape, TimeTicket } from './Shape';
 import { drawLine, createLine } from './utils';
+import * as schedule from './schedule';
 
 interface Options {
   color: string;
@@ -12,8 +13,6 @@ enum DragStatus {
   Drag,
   Stop,
 }
-
-let dragStatus = DragStatus.Stop;
 
 export default class Container {
   pointY: number;
@@ -30,6 +29,8 @@ export default class Container {
 
   createId?: TimeTicket;
 
+  dragStatus: DragStatus;
+
   update: Function;
 
   options: Options;
@@ -38,6 +39,7 @@ export default class Container {
     this.pointY = 0;
     this.pointX = 0;
     this.tool = Tool.Line;
+    this.dragStatus = DragStatus.Stop;
     this.update = update;
     this.options = options;
     this.scene = new Canvas(el);
@@ -53,6 +55,7 @@ export default class Container {
     this.scene.getContext().strokeStyle = this.options.color;
 
     this.scene.getCanvas().onmouseup = this.onmouseup.bind(this);
+    this.scene.getCanvas().onmouseout = this.onmouseup.bind(this);
     this.scene.getCanvas().onmousedown = this.onmousedown.bind(this);
     this.scene.getCanvas().onmousemove = this.onmousemove.bind(this);
   }
@@ -84,7 +87,7 @@ export default class Container {
       return;
     }
 
-    dragStatus = DragStatus.Drag;
+    this.dragStatus = DragStatus.Drag;
 
     this.update((root: Root) => {
       if (this.tool === Tool.Line) {
@@ -94,6 +97,18 @@ export default class Container {
         this.createId = lastShape.getID();
       }
     });
+
+    schedule.requestHostCallback((tasks) => {
+      this.update((root: Root) => {
+        if (this.tool === Tool.Line) {
+          const points = tasks.map((task) => task.point);
+          const lastShape = root.shapes.getElementByID(this.createId) as Line;
+
+          lastShape.points.push(...points);
+          this.drawAll(root.shapes);
+        }
+      });
+    });
   }
 
   onmousemove(evt: MouseEvent) {
@@ -102,21 +117,19 @@ export default class Container {
       return;
     }
 
-    if (dragStatus === DragStatus.Stop) {
+    if (this.dragStatus === DragStatus.Stop) {
       return;
     }
 
-    this.update((root: Root) => {
-      if (this.tool === Tool.Line) {
-        const lastShape = root.shapes.getElementByID(this.createId) as Line;
-        lastShape.points.push(point);
-        this.drawAll(root.shapes);
-      }
+    schedule.reserveTask({
+      point,
     });
   }
 
   onmouseup() {
-    dragStatus = DragStatus.Stop;
+    this.dragStatus = DragStatus.Stop;
+
+    schedule.requestHostWorkFlush();
     this.createId = undefined;
   }
 

--- a/src/components/Editor/Board/Canvas/Container.ts
+++ b/src/components/Editor/Board/Canvas/Container.ts
@@ -1,7 +1,7 @@
 import { Tool } from 'features/boardSlices';
 import Canvas from './Canvas';
 
-import { Root, Line, Shapes, Shape, TimeTicket } from './Shape';
+import { Root, Point, Line, Shapes, Shape, TimeTicket } from './Shape';
 import { drawLine, createLine } from './utils';
 
 interface Options {
@@ -71,14 +71,16 @@ export default class Container {
     }
   }
 
-  getMouse(evt: MouseEvent) {
-    this.pointY = evt.pageY - this.offsetY;
-    this.pointX = evt.pageX - this.offsetX;
+  getMouse(evt: MouseEvent): Point {
+    return {
+      y: evt.pageY - this.offsetY,
+      x: evt.pageX - this.offsetX,
+    };
   }
 
   onmousedown(evt: MouseEvent) {
-    this.getMouse(evt);
-    if (this.isOutSide()) {
+    const point = this.getMouse(evt);
+    if (this.isOutSide(point)) {
       return;
     }
 
@@ -86,7 +88,7 @@ export default class Container {
 
     this.update((root: Root) => {
       if (this.tool === Tool.Line) {
-        const shape = createLine(this.pointY, this.pointX);
+        const shape = createLine(point);
         root.shapes.push(shape);
         const lastShape = root.shapes.getLast();
         this.createId = lastShape.getID();
@@ -95,8 +97,8 @@ export default class Container {
   }
 
   onmousemove(evt: MouseEvent) {
-    this.getMouse(evt);
-    if (this.isOutSide()) {
+    const point = this.getMouse(evt);
+    if (this.isOutSide(point)) {
       return;
     }
 
@@ -107,10 +109,7 @@ export default class Container {
     this.update((root: Root) => {
       if (this.tool === Tool.Line) {
         const lastShape = root.shapes.getElementByID(this.createId) as Line;
-        lastShape.points.push({
-          x: this.pointX,
-          y: this.pointY,
-        });
+        lastShape.points.push(point);
         this.drawAll(root.shapes);
       }
     });
@@ -121,13 +120,8 @@ export default class Container {
     this.createId = undefined;
   }
 
-  isOutSide() {
-    if (
-      this.pointY < 0 ||
-      this.pointX < 0 ||
-      this.pointY > this.scene.getHeight() ||
-      this.pointX > this.scene.getWidth()
-    ) {
+  isOutSide(point: Point) {
+    if (point.y < 0 || point.x < 0 || point.y > this.scene.getHeight() || point.x > this.scene.getWidth()) {
       this.onmouseup();
       return true;
     }

--- a/src/components/Editor/Board/Canvas/Shape.ts
+++ b/src/components/Editor/Board/Canvas/Shape.ts
@@ -1,7 +1,7 @@
 // TODO(ppeeou) refer to yorkie-sdk-js TimeTicket
 export type TimeTicket = any;
 
-type Point = {
+export type Point = {
   y: number;
   x: number;
 };

--- a/src/components/Editor/Board/Canvas/schedule.ts
+++ b/src/components/Editor/Board/Canvas/schedule.ts
@@ -1,0 +1,34 @@
+import { Point } from './Shape';
+
+export type Task = {
+  point: Point;
+};
+
+const INTERVAL_TIME = 50;
+let tasks: Array<Task> = [];
+let intervalId: number;
+let work: Function | undefined;
+
+export function requestHostCallback(callback: (tasks: Array<Task>) => void) {
+  work = () => {
+    if (tasks.length > 0) {
+      callback(tasks);
+      tasks = [];
+    }
+  };
+
+  intervalId = setInterval(work, INTERVAL_TIME);
+}
+
+export function reserveTask(task: Task) {
+  tasks.push(task);
+}
+
+export function requestHostWorkFlush() {
+  clearInterval(intervalId);
+
+  if (typeof work === 'function') {
+    work();
+  }
+  work = undefined;
+}

--- a/src/components/Editor/Board/Canvas/utils.ts
+++ b/src/components/Editor/Board/Canvas/utils.ts
@@ -1,4 +1,4 @@
-import { Line } from './Shape';
+import { Line, Point } from './Shape';
 
 export function drawLine(context: CanvasRenderingContext2D, line: Line) {
   context.beginPath();
@@ -15,14 +15,9 @@ export function drawLine(context: CanvasRenderingContext2D, line: Line) {
   context.stroke();
 }
 
-export function createLine(pointY: number, pointX: number): Line {
+export function createLine(point: Point): Line {
   return {
     type: 'line',
-    points: [
-      {
-        x: pointX,
-        y: pointY,
-      },
-    ],
+    points: [point],
   } as Line;
 }

--- a/src/components/Editor/Board/Canvas/utils.ts
+++ b/src/components/Editor/Board/Canvas/utils.ts
@@ -21,3 +21,107 @@ export function createLine(point: Point): Line {
     points: [point],
   } as Line;
 }
+
+/**
+ * square distance between 2 points
+ */
+function getSqDist(p1: Point, p2: Point) {
+  const dx = p1.x - p2.x;
+  const dy = p1.y - p2.y;
+
+  return dx * dx + dy * dy;
+}
+
+/**
+ * square distance from a point to a segment
+ */
+function getSqSegDist(p: Point, p1: Point, p2: Point) {
+  let { x, y } = p1;
+  let dx = p2.x - x;
+  let dy = p2.y - y;
+
+  if (dx !== 0 || dy !== 0) {
+    const t = ((p.x - x) * dx + (p.y - y) * dy) / (dx * dx + dy * dy);
+    if (t > 1) {
+      x = p2.x;
+      y = p2.y;
+    } else if (t > 0) {
+      x += dx * t;
+      y += dy * t;
+    }
+  }
+
+  dx = p.x - x;
+  dy = p.y - y;
+  return dx * dx + dy * dy;
+}
+
+function douglasPeuckerStep(
+  points: Array<Point>,
+  first: number,
+  last: number,
+  tolerance: number,
+  simplified: Array<Point>,
+) {
+  let maxDist = tolerance;
+  let index = 0;
+
+  for (let i = first + 1; i < last; i += 1) {
+    const dist = getSqSegDist(points[i], points[first], points[last]);
+
+    if (dist > maxDist) {
+      index = i;
+      maxDist = dist;
+    }
+  }
+
+  if (maxDist > tolerance) {
+    if (first + 1 < index) {
+      douglasPeuckerStep(points, first, index, tolerance, simplified);
+    }
+    simplified.push(points[index]);
+    if (index + 1 < last) {
+      douglasPeuckerStep(points, index, last, tolerance, simplified);
+    }
+  }
+}
+
+function douglasPeucker(points: Array<Point>, tolerance: number): Array<Point> {
+  const first = 0;
+  const last = points.length - 1;
+  const simplified = [];
+
+  simplified.push(points[first]);
+  douglasPeuckerStep(points, first, last, tolerance, simplified);
+  simplified.push(points[last]);
+
+  return simplified;
+}
+
+function simplifyRadialDist(points: Array<Point>, tolerance: number) {
+  let point = points[0];
+  let prevPoint = point;
+  const simplified = [prevPoint];
+
+  for (let i = 1, len = points.length; i < len; i += 1) {
+    point = points[i];
+
+    if (getSqDist(point, prevPoint) > tolerance) {
+      simplified.push(point);
+      prevPoint = point;
+    }
+  }
+
+  if (prevPoint !== point) {
+    simplified.push(point);
+  }
+  return simplified;
+}
+
+/**
+ * @see {@link https://cartography-playground.gitlab.io/playgrounds/douglas-peucker-algorithm/}
+ * @see {@link https://github.com/mourner/simplify-js}
+ */
+export function compressPoints(points: Array<Point>, tolerance: number = 10): Array<Point> {
+  return douglasPeucker(simplifyRadialDist(points, tolerance), tolerance);
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?


Currently, every time the user moves the mouse point, all points are recorded, so a lot of unnecessary data is stored.


When passing, the accumulated value is reduced and stored through the [douglas-peucker-algorithm](https://cartography-playground.gitlab.io/playgrounds/douglas-peucker-algorithm/)


The following shows the reduced results when applied

#### as- is

points length 

left draw 10: 3185 , right draw 1: 528
![image](https://user-images.githubusercontent.com/10924072/109406511-14392000-79bd-11eb-8a78-d318ebcc159d.png)


#### to-be

points length

left draw 10: 623 , right draw 1: 89
![image](https://user-images.githubusercontent.com/10924072/109406520-261ac300-79bd-11eb-98ad-044c26dc2444.png)


It seems that the average number of stored points reduced to 1/6
 

#### Any background context you want to provide?

douglas-peucker-algorithm

https://cartography-playground.gitlab.io/playgrounds/douglas-peucker-algorithm/

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #48

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
