### PR TITLE
Separate document update purposes into worker class

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,9 @@
   "rules": {
     "no-restricted-syntax": 0,
     "no-continue": 0,
-    "react/jsx-one-expression-per-line": 0
+    "react/jsx-one-expression-per-line": 0,
+    "class-methods-use-this": 0,
+    "import/prefer-default-export": 0
   },
   "plugins": ["@typescript-eslint"]
 }

--- a/src/components/Editor/Board/Canvas/Container.ts
+++ b/src/components/Editor/Board/Canvas/Container.ts
@@ -1,10 +1,9 @@
 import { Tool } from 'features/boardSlices';
 import Canvas from './Canvas';
 
-import { Root, Point, Line, Shapes, Shape, TimeTicket } from './Shape';
-import { compressPoints } from './utils';
-import { drawLine, createLine } from './line';
-import * as schedule from './schedule';
+import { Point, Line, Shapes, Shape, TimeTicket } from './Shape';
+import { drawLine } from './line';
+import Worker from './worker';
 
 interface Options {
   color: string;
@@ -36,6 +35,8 @@ export default class Container {
 
   options: Options;
 
+  worker: Worker;
+
   constructor(el: HTMLCanvasElement, update: Function, options: Options) {
     this.pointY = 0;
     this.pointX = 0;
@@ -50,11 +51,14 @@ export default class Container {
     this.offsetX = x;
 
     this.init();
+
+    this.worker = new Worker(this.update);
   }
 
   init() {
     this.scene.getContext().strokeStyle = this.options.color;
 
+    this.drawAll = this.drawAll.bind(this);
     this.scene.getCanvas().onmouseup = this.onmouseup.bind(this);
     this.scene.getCanvas().onmouseout = this.onmouseup.bind(this);
     this.scene.getCanvas().onmousedown = this.onmousedown.bind(this);
@@ -90,26 +94,10 @@ export default class Container {
 
     this.dragStatus = DragStatus.Drag;
 
-    this.update((root: Root) => {
-      if (this.tool === Tool.Line) {
-        const shape = createLine(point);
-        root.shapes.push(shape);
-        const lastShape = root.shapes.getLast();
-        this.createId = lastShape.getID();
-      }
-    });
-
-    schedule.requestHostCallback((tasks) => {
-      this.update((root: Root) => {
-        if (this.tool === Tool.Line) {
-          const points = tasks.map((task) => task.point);
-          const lastShape = root.shapes.getElementByID(this.createId) as Line;
-
-          lastShape.points.push(...compressPoints(points));
-          this.drawAll(root.shapes);
-        }
-      });
-    });
+    if (this.worker.isRecordWork(this.tool)) {
+      this.createId = this.worker.createShape(this.tool, point);
+      this.worker.executeTask(this.createId, this.tool, this.drawAll);
+    }
   }
 
   onmousemove(evt: MouseEvent) {
@@ -122,16 +110,20 @@ export default class Container {
       return;
     }
 
-    schedule.reserveTask({
-      point,
-    });
+    if (this.worker.isRecordWork(this.tool)) {
+      this.worker.reserveTask({
+        point,
+      });
+    }
   }
 
   onmouseup() {
     this.dragStatus = DragStatus.Stop;
 
-    schedule.requestHostWorkFlush();
-    this.createId = undefined;
+    if (this.worker.isRecordWork(this.tool)) {
+      this.worker.flushTask();
+      this.createId = undefined;
+    }
   }
 
   isOutSide(point: Point) {

--- a/src/components/Editor/Board/Canvas/Container.ts
+++ b/src/components/Editor/Board/Canvas/Container.ts
@@ -2,7 +2,8 @@ import { Tool } from 'features/boardSlices';
 import Canvas from './Canvas';
 
 import { Root, Point, Line, Shapes, Shape, TimeTicket } from './Shape';
-import { drawLine, createLine, compressPoints } from './utils';
+import { compressPoints } from './utils';
+import { drawLine, createLine } from './line';
 import * as schedule from './schedule';
 
 interface Options {

--- a/src/components/Editor/Board/Canvas/line.ts
+++ b/src/components/Editor/Board/Canvas/line.ts
@@ -1,0 +1,29 @@
+import { Line, Point } from './Shape';
+
+/**
+ * Create the basic object of the line with point.
+ */
+export function createLine(point: Point): Line {
+  return {
+    type: 'line',
+    points: [point],
+  } as Line;
+}
+
+/**
+ * Draw a line on the canvas.
+ */
+export function drawLine(context: CanvasRenderingContext2D, line: Line) {
+  context.beginPath();
+
+  let isMoved = false;
+  for (const p of line.points) {
+    if (isMoved === false) {
+      isMoved = true;
+      context.moveTo(p.x, p.y);
+    } else {
+      context.lineTo(p.x, p.y);
+    }
+  }
+  context.stroke();
+}

--- a/src/components/Editor/Board/Canvas/utils.ts
+++ b/src/components/Editor/Board/Canvas/utils.ts
@@ -1,26 +1,4 @@
-import { Line, Point } from './Shape';
-
-export function drawLine(context: CanvasRenderingContext2D, line: Line) {
-  context.beginPath();
-
-  let isMoved = false;
-  for (const p of line.points) {
-    if (isMoved === false) {
-      isMoved = true;
-      context.moveTo(p.x, p.y);
-    } else {
-      context.lineTo(p.x, p.y);
-    }
-  }
-  context.stroke();
-}
-
-export function createLine(point: Point): Line {
-  return {
-    type: 'line',
-    points: [point],
-  } as Line;
-}
+import { Point } from './Shape';
 
 /**
  * square distance between 2 points

--- a/src/components/Editor/Board/Canvas/worker.ts
+++ b/src/components/Editor/Board/Canvas/worker.ts
@@ -1,0 +1,74 @@
+import { Tool } from 'features/boardSlices';
+
+import { Root, Point, Line, TimeTicket } from './Shape';
+import { compressPoints } from './utils';
+import { createLine } from './line';
+import * as schedule from './schedule';
+
+export default class Worker {
+  update: Function;
+
+  constructor(update: Function) {
+    this.update = update;
+  }
+
+  /**
+   * Check if the work is to be recorded
+   */
+  isRecordWork(tool: Tool) {
+    if (tool === Tool.Line) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Create shape according to tool
+   */
+  createShape(tool: Tool, point: Point): TimeTicket {
+    let createId;
+
+    this.update((root: Root) => {
+      if (tool === Tool.Line) {
+        const shape = createLine(point);
+        root.shapes.push(shape);
+      }
+
+      const lastShape = root.shapes.getLast();
+      createId = lastShape.getID();
+    });
+
+    return createId;
+  }
+
+  /**
+   * Task execution by scheduler
+   */
+  executeTask(createId: TimeTicket, tool: Tool, callback: Function) {
+    schedule.requestHostCallback((tasks) => {
+      this.update((root: Root) => {
+        if (tool === Tool.Line) {
+          const points = compressPoints(tasks.map((task) => task.point));
+          const lastShape = root.shapes.getElementByID(createId) as Line;
+
+          lastShape.points.push(...points);
+          callback(root.shapes);
+        }
+      });
+    });
+  }
+
+  /**
+   * Schedule the task to be executed in the scheduler
+   */
+  reserveTask(task: schedule.Task) {
+    schedule.reserveTask(task);
+  }
+
+  /**
+   * Flush existing tasks in the scheduler
+   */
+  flushTask() {
+    schedule.requestHostWorkFlush();
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Separate functions into functions or classes.

what
- Separate functions for line in utils
- Separate document update purposes into worker class

why
Because Container class was working in various ways before,
It separates the two tasks: drawing the canvas and updating the document.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
