### PR TITLE
Bugfix no line is visible in light mode

### DIFF
--- a/src/components/Editor/Board/Content.tsx
+++ b/src/components/Editor/Board/Content.tsx
@@ -36,7 +36,7 @@ export default function Content() {
       canvasRef.current.height = height;
 
       const options = {
-        color: grey[50],
+        color: grey[500],
         eraserColor: deepOrange[400],
       };
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

The lines are not visible because they are mild gray in light mode.

After that, we need to be able to choose the color of the line.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
