### PR TITLE
Support retina on canvas

### DIFF
--- a/src/components/Editor/Board/Canvas/Canvas.ts
+++ b/src/components/Editor/Board/Canvas/Canvas.ts
@@ -4,9 +4,9 @@ export default class Canvas {
   // eslint-disable-next-line react/static-property-placement
   private context: CanvasRenderingContext2D;
 
-  width = 0;
+  private width = 0;
 
-  height = 0;
+  private height = 0;
 
   constructor(canvas: HTMLCanvasElement) {
     this.canvas = canvas;
@@ -30,21 +30,21 @@ export default class Canvas {
     return this.height;
   }
 
-  setWidth(width: number) {
-    this.canvas.width = width;
+  setWidth(width: number, devicePixelRatio?: number) {
     this.width = width;
+    this.canvas.width = devicePixelRatio ? width * devicePixelRatio : width;
     this.canvas.style.width = `${width}px`;
   }
 
-  setHeight(height: number) {
-    this.canvas.height = height;
+  setHeight(height: number, devicePixelRatio?: number) {
     this.height = height;
+    this.canvas.height = devicePixelRatio ? height * devicePixelRatio : height;
     this.canvas.style.height = `${height}px`;
   }
 
-  setSize(width: number, height: number) {
-    this.setWidth(width);
-    this.setHeight(height);
+  setSize(width: number, height: number, devicePixelRatio?: number) {
+    this.setWidth(width, devicePixelRatio);
+    this.setHeight(height, devicePixelRatio);
   }
 
   clear() {
@@ -52,6 +52,12 @@ export default class Canvas {
   }
 
   resize() {
-    this.setSize(this.canvas.width, this.canvas.height);
+    const { devicePixelRatio } = window;
+    if (devicePixelRatio) {
+      this.setSize(this.canvas.width, this.canvas.height, devicePixelRatio);
+      this.context.scale(devicePixelRatio, devicePixelRatio);
+    } else {
+      this.setSize(this.canvas.width, this.canvas.height);
+    }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Supports retina display

as-is

![image](https://user-images.githubusercontent.com/10924072/111076201-b6fdac80-852e-11eb-8349-3b1eab695d8e.png)

to-be
![image](https://user-images.githubusercontent.com/10924072/111076211-c1b84180-852e-11eb-8cae-575c8911bbd2.png)

#### Any background context you want to provide?

https://geoexamples.com/d3/2017/10/24/canvas-mapping-with-retina.html

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #50 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
