### PR TITLE
Bugfix a bug TouchEvent is not defined on canvas

### DIFF
--- a/src/components/Editor/Board/Canvas/Container.ts
+++ b/src/components/Editor/Board/Canvas/Container.ts
@@ -8,6 +8,8 @@ import { drawLine } from './line';
 import Worker from './worker';
 import { addEvent, removeEvent, touchy } from './dom';
 
+type TouchyEvent = MouseEvent & TouchEvent;
+
 interface Options {
   color: string;
   eraserColor: string;
@@ -93,10 +95,10 @@ export default class Container {
     }
   }
 
-  getMouse(evt: MouseEvent | TouchEvent): Point {
+  getMouse(evt: TouchyEvent): Point {
     let originY;
     let originX;
-    if (evt instanceof TouchEvent) {
+    if (window.TouchEvent && evt instanceof TouchEvent) {
       originY = evt.touches[0].clientY;
       originX = evt.touches[0].clientX;
     } else {
@@ -111,7 +113,7 @@ export default class Container {
     };
   }
 
-  onmousedown(evt: MouseEvent) {
+  onmousedown(evt: TouchyEvent) {
     touchy(this.scene.getCanvas(), addEvent, 'mousemove', this.onmousemove as EventListener);
     this.dragStatus = DragStatus.Drag;
 
@@ -122,7 +124,7 @@ export default class Container {
     }
   }
 
-  onmousemove(evt: MouseEvent) {
+  onmousemove(evt: TouchyEvent) {
     const point = this.getMouse(evt);
     if (this.isOutSide(point)) {
       return;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Firefox, opera, and explore do not support touch event.
Touch values are used only when there is a touch event.

I haven't tested it for all browser versions, but it seems to work with most browsers.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #73 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
