### PR TITLE
Provide the app dark/light mode in settings

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,19 +1,21 @@
 import React, { useMemo, useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { HashRouter as Router, Route, Redirect } from 'react-router-dom';
-import useMediaQuery from '@material-ui/core/useMediaQuery';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { AppState } from 'app/rootReducer';
+import { Theme } from 'features/settingSlices';
 
 import DocPage from 'pages/DocPage';
 import './App.css';
 
 function App() {
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+  const menu = useSelector((state: AppState) => state.settingState.menu);
   const theme = useMemo(
     () =>
       createMuiTheme({
         palette: {
-          type: prefersDarkMode ? 'dark' : 'light',
+          type: menu.theme === Theme.Dark ? 'dark' : 'light',
           primary: {
             main: '#d8b01a',
           },
@@ -22,7 +24,7 @@ function App() {
           },
         },
       }),
-    [prefersDarkMode],
+    [menu],
   );
 
   const handleRender = useCallback(() => {

--- a/src/components/Editor/CodeEditor/index.tsx
+++ b/src/components/Editor/CodeEditor/index.tsx
@@ -5,6 +5,7 @@ import { UnControlled as CodeMirror } from 'react-codemirror2';
 
 import { AppState } from 'app/rootReducer';
 import { ConnectionStatus, Metadata } from 'features/peerSlices';
+import { Theme } from 'features/settingSlices';
 
 import Cursor from './Cursor';
 
@@ -26,7 +27,7 @@ import 'codemirror/keymap/vim';
 
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/monokai.css';
-import 'codemirror/theme/material.css';
+import 'codemirror/theme/xq-light.css';
 import './index.css';
 
 export default function CodeEditor() {
@@ -70,7 +71,7 @@ export default function CodeEditor() {
       className="CodeMirror"
       options={{
         mode: codeMode,
-        theme: menu.codeTheme,
+        theme: menu.theme === Theme.Dark ? 'monokai' : 'xq-light',
         keyMap: menu.codeKeyMap,
         tabSize: Number(menu.tabSize),
         lineNumbers: true,

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -40,7 +40,7 @@ function MenuAppBar() {
       <AppBar position="static" className={classes.appBar}>
         <Toolbar>
           <Typography variant="h6" className={classes.title}>
-            Yorkie CodePair
+            CodePair
           </Typography>
           <NetworkButton />
           <div className={classes.grow} />

--- a/src/components/Toolbar/Settings.tsx
+++ b/src/components/Toolbar/Settings.tsx
@@ -8,7 +8,7 @@ import Typography from '@material-ui/core/Typography';
 import FormControl from '@material-ui/core/FormControl';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 
-import { CodeTheme, CodeKeyMap, TabSize, setCodeTheme, setCodeKeyMap, setTabSize } from 'features/settingSlices';
+import { Theme, CodeKeyMap, TabSize, setTheme, setCodeKeyMap, setTabSize } from 'features/settingSlices';
 import { AppState } from 'app/rootReducer';
 
 const useStyles = makeStyles((theme) =>
@@ -72,8 +72,8 @@ const Settings = () => {
         <div className={classes.item}>
           <div className={classes.itemTitle}>Theme</div>
           <FormControl className={classes.itemInfo}>
-            <Select value={menu.codeTheme} onChange={handleChange(setCodeTheme)} disableUnderline displayEmpty>
-              {Object.entries(CodeTheme).map(([display, theme]: [string, string]) => {
+            <Select value={menu.theme} onChange={handleChange(setTheme)} disableUnderline displayEmpty>
+              {Object.entries(Theme).map(([display, theme]: [string, string]) => {
                 return (
                   <MenuItem value={theme} key={theme}>
                     {display}

--- a/src/features/settingSlices.ts
+++ b/src/features/settingSlices.ts
@@ -1,9 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import BrowserStorage from 'utils/storage';
 
-export enum CodeTheme {
-  Material = 'material',
-  Monokai = 'monokai',
+export enum Theme {
+  Dark = 'dark',
+  Light = 'light',
 }
 
 export enum CodeKeyMap {
@@ -18,7 +18,7 @@ export enum TabSize {
   Eight = '8',
 }
 
-export type MenuKey = 'codeTheme' | 'codeKeyMap' | 'tabSize';
+export type MenuKey = 'theme' | 'codeKeyMap' | 'tabSize';
 
 export type Menu = {
   [key in MenuKey]: string;
@@ -32,7 +32,7 @@ const SettingModel = new BrowserStorage<SettingState>('$$codepair$$setting');
 
 const initialState: SettingState = SettingModel.getValue({
   menu: {
-    codeTheme: CodeTheme.Monokai,
+    theme: Theme.Dark,
     codeKeyMap: CodeKeyMap.Sublime,
     tabSize: TabSize.Two,
   },
@@ -42,9 +42,8 @@ const settingSlice = createSlice({
   name: 'setting',
   initialState,
   reducers: {
-
-    setCodeTheme(state, action: PayloadAction<CodeTheme>) {
-      state.menu.codeTheme = action.payload;
+    setTheme(state, action: PayloadAction<Theme>) {
+      state.menu.theme = action.payload;
       SettingModel.setValue(state);
     },
 
@@ -60,5 +59,5 @@ const settingSlice = createSlice({
   },
 });
 
-export const { setCodeTheme, setCodeKeyMap, setTabSize } = settingSlice.actions;
+export const { setTheme, setCodeKeyMap, setTabSize } = settingSlice.actions;
 export default settingSlice.reducer;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Provide the app dark/light mode in settings.

<img width="1002" alt="Screen Shot 2021-03-30 at 18 43 30" src="https://user-images.githubusercontent.com/2059311/112969059-dd0a8a00-9187-11eb-81a0-b2bcdd441e70.png">


#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #58 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
