### PR TITLE
Focus on Code Editor when clicking on an empty space

### DIFF
--- a/src/components/Editor/CodeEditor/index.tsx
+++ b/src/components/Editor/CodeEditor/index.tsx
@@ -30,7 +30,11 @@ import 'codemirror/theme/monokai.css';
 import 'codemirror/theme/xq-light.css';
 import './index.css';
 
-export default function CodeEditor() {
+interface CodeEditorProps {
+  forwardedRef: React.MutableRefObject<CodeMirror.Editor | null>;
+}
+
+export default function CodeEditor({ forwardedRef }: CodeEditorProps) {
   const doc = useSelector((state: AppState) => state.docState.doc);
   const codeMode = useSelector((state: AppState) => state.docState.mode);
   const client = useSelector((state: AppState) => state.docState.client);
@@ -38,12 +42,9 @@ export default function CodeEditor() {
   const menu = useSelector((state: AppState) => state.settingState.menu);
   const cursorMapRef = useRef<Map<ActorID, Cursor>>(new Map());
 
-  const connectCursor = useCallback(
-    (clientID: ActorID, metadata: Metadata) => {
-      cursorMapRef.current.set(clientID, new Cursor(clientID, metadata));
-    },
-    [peers],
-  );
+  const connectCursor = useCallback((clientID: ActorID, metadata: Metadata) => {
+    cursorMapRef.current.set(clientID, new Cursor(clientID, metadata));
+  }, []);
 
   const disconnectCursor = useCallback((clientID: ActorID) => {
     if (cursorMapRef.current.has(clientID)) {
@@ -80,6 +81,9 @@ export default function CodeEditor() {
         autoCloseBrackets: true,
       }}
       editorDidMount={(editor: CodeMirror.Editor) => {
+        // eslint-disable-next-line no-param-reassign
+        forwardedRef.current = editor;
+
         editor.focus();
         const updateCursor = (clientID: ActorID, pos: CodeMirror.Position) => {
           const cursor = cursorMapRef.current.get(clientID);

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 
 import CodeEditor from 'components/Editor/CodeEditor';
@@ -48,6 +48,13 @@ export default function Editor({ tool }: EditorProps) {
   const [height, setHeight] = useState(0);
 
   const divRef = useRef<HTMLDivElement>(null);
+  const codeEditorRef = useRef<CodeMirror.Editor>(null);
+
+  const onClickEditor = useCallback(() => {
+    if (tool === Tool.None) {
+      codeEditorRef.current?.focus();
+    }
+  }, [tool]);
 
   useEffect(() => {
     const onResize = () => {
@@ -68,10 +75,10 @@ export default function Editor({ tool }: EditorProps) {
   }, []);
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} onClick={onClickEditor} aria-hidden="true">
       <div className={classes.editor} ref={divRef}>
         <div className={classes.codeEditor}>
-          <CodeEditor />
+          <CodeEditor forwardedRef={codeEditorRef} />
         </div>
         <div className={classes.canvas}>
           <Board width={width} height={height} />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?


I thought that if I use `z-index` well, can implement the function.
When doing so, a problem occurs when the `canvas` and `codeEditor` overlap.

So, I used the click event to perform the focus function.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #80

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
