### PR TITLE
Removes the reverse traversal function, when selected

### DIFF
--- a/src/components/Editor/Board/Canvas/utils.ts
+++ b/src/components/Editor/Board/Canvas/utils.ts
@@ -1,4 +1,4 @@
-import { Point, Box, Shapes } from './Shape';
+import { Point, Box } from './Shape';
 
 /**
  * square distance between 2 points
@@ -183,12 +183,4 @@ export function isInnerBox(box: Box, point: Point): boolean {
     return false;
   }
   return true;
-}
-
-export function* reverseIter(arr: Shapes) {
-  let l = arr.length - 1;
-  while (l >= 0) {
-    yield arr[l];
-    l -= 1;
-  }
 }

--- a/src/components/Editor/Board/Canvas/worker.ts
+++ b/src/components/Editor/Board/Canvas/worker.ts
@@ -3,7 +3,7 @@ import { TimeTicket } from 'yorkie-js-sdk';
 import { Tool } from 'features/boardSlices';
 
 import { Root, Shape, Point, Line, Rect } from './Shape';
-import { compressPoints, checkLineIntersection, reverseIter, isInnerBox, cloneBox } from './utils';
+import { compressPoints, checkLineIntersection, isInnerBox, cloneBox } from './utils';
 import { createLine, createEraserLine, fixEraserPoint } from './line';
 import { createRect, adjustRectBox } from './rect';
 import * as schedule from './schedule';
@@ -53,7 +53,7 @@ export default class Worker {
    */
   selectShape(point: Point): Shape | undefined {
     this.update((root: Root) => {
-      for (const shape of reverseIter(root.shapes)) {
+      for (const shape of root.shapes) {
         if (shape?.box && isInnerBox(shape.box, point)) {
           this.selectedShape = {
             shape,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

It seems that an error occurs in the part that checks the length during reverse traversal.
First, it will be bypassed and corrected in the direction of straight 

https://github.com/yorkie-team/yorkie-codepair/issues/44#issuecomment-812996079

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
