### PR TITLE
Change Selector tool, after creating a controllable shape

### DIFF
--- a/src/components/Editor/Board/Canvas/Container.ts
+++ b/src/components/Editor/Board/Canvas/Container.ts
@@ -1,12 +1,13 @@
 import { TimeTicket } from 'yorkie-js-sdk';
 import { Tool } from 'features/boardSlices';
 import { Shape } from 'features/docSlices';
-import Canvas from './Canvas';
+import EventDispatcher from 'utils/eventDispatcher';
 
+import Canvas from './Canvas';
+import Worker from './worker';
 import { Point, Line, EraserLine, Rect } from './Shape';
 import { drawLine } from './line';
 import { drawRect } from './rect';
-import Worker from './worker';
 import { addEvent, removeEvent, touchy, TouchyEvent } from './dom';
 
 interface Options {
@@ -42,6 +43,8 @@ export default class Container {
 
   worker: Worker;
 
+  eventDispatcher: EventDispatcher;
+
   constructor(el: HTMLCanvasElement, update: Function, options: Options) {
     this.pointY = 0;
     this.pointX = 0;
@@ -50,6 +53,7 @@ export default class Container {
     this.update = update;
     this.options = options;
     this.scene = new Canvas(el);
+    this.eventDispatcher = new EventDispatcher();
 
     const { y, x } = this.scene.getCanvas().getBoundingClientRect();
     this.offsetY = y;
@@ -164,6 +168,7 @@ export default class Container {
     }
 
     this.createId = undefined;
+    this.emit('mouseup');
   }
 
   isOutSide(point: Point) {
@@ -193,5 +198,17 @@ export default class Container {
 
   clear() {
     this.scene.clear();
+  }
+
+  emit(name: string, ...args: Array<unknown>) {
+    this.eventDispatcher.emit(name, ...args);
+  }
+
+  on(name: string, cb: Function) {
+    this.eventDispatcher.addEventListener(name, cb);
+  }
+
+  off(name: string, cb: Function) {
+    this.eventDispatcher.removeEventListener(name, cb);
   }
 }

--- a/src/components/Editor/Board/index.tsx
+++ b/src/components/Editor/Board/index.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import grey from '@material-ui/core/colors/grey';
 import deepOrange from '@material-ui/core/colors/deepOrange';
 
 import { AppState } from 'app/rootReducer';
+import { Tool, setTool } from 'features/boardSlices';
 
 import Container from './Canvas/Container';
 import './index.css';
@@ -11,6 +12,7 @@ import './index.css';
 export default function Board({ width, height }: { width: number; height: number }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<Container | null>(null);
+  const dispatch = useDispatch();
   const doc = useSelector((state: AppState) => state.docState.doc);
   const tool = useSelector((state: AppState) => state.boardState.tool);
 
@@ -32,7 +34,16 @@ export default function Board({ width, height }: { width: number; height: number
     containerRef.current.setTool(tool);
     containerRef.current.drawAll(doc.getRoot().shapes);
 
+    const handleMouseup = () => {
+      if (tool === Tool.Rect) {
+        dispatch(setTool(Tool.Selector));
+      }
+    };
+
+    containerRef.current.on('mouseup', handleMouseup);
+
     return () => {
+      containerRef.current?.off('mouseup', handleMouseup);
       container.destroy();
     };
   }, [width, height, doc, tool]);

--- a/src/utils/eventDispatcher.ts
+++ b/src/utils/eventDispatcher.ts
@@ -1,0 +1,59 @@
+/* eslint-disable max-classes-per-file */
+class Event {
+  private name: string;
+
+  callbacks: Array<Function>;
+
+  constructor(name: string) {
+    this.name = name;
+    this.callbacks = [];
+  }
+
+  on(cb: Function) {
+    this.callbacks.push(cb);
+  }
+
+  off(cb: Function) {
+    const idx = this.callbacks.findIndex((callback) => callback === cb);
+    this.callbacks.splice(idx, 1);
+  }
+
+  toString() {
+    return this.name;
+  }
+}
+
+export default class EventDispatcher {
+  events: { [name: string]: Event };
+
+  constructor() {
+    this.events = {};
+  }
+
+  emit(name: string, ...args: Array<unknown>) {
+    if (!this.events[name]) {
+      return;
+    }
+
+    this.events[name].callbacks.forEach((cb) => {
+      cb(...args);
+    });
+  }
+
+  addEventListener(name: string, cb: Function): void {
+    if (!this.events[name]) {
+      this.events[name] = new Event(name);
+    }
+
+    this.events[name].on(cb);
+  }
+
+  removeEventListener(name: string, cb?: Function) {
+    if (!cb) {
+      delete this.events[name];
+      return;
+    }
+
+    this.events[name].off(cb);
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?


Change Selector tool, after creating a controllable shape

Most editors provide the user to create a shape and then immediately change it to the selector tool.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
