### PR TITLE
Use save restore, When modifying canvas context

### DIFF
--- a/src/components/Editor/Board/Canvas/line.ts
+++ b/src/components/Editor/Board/Canvas/line.ts
@@ -31,9 +31,9 @@ export function createEraserLine(point: Point): EraserLine {
  * Draw a line on the canvas.
  */
 export function drawLine(context: CanvasRenderingContext2D, line: Line | EraserLine) {
+  context.save();
   context.beginPath();
 
-  const originColor = context.strokeStyle;
   context.strokeStyle =
     line.type === 'eraser'
       ? '#ff7043' // eraser color
@@ -49,8 +49,8 @@ export function drawLine(context: CanvasRenderingContext2D, line: Line | EraserL
     }
   }
   context.stroke();
-  context.strokeStyle = originColor;
   context.closePath();
+  context.restore();
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Usually, when modifying the canvas context, context save and restore are used

#### Any background context you want to provide?

https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/save
https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/restore

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
