### PR TITLE
Update yorkie-js-sdk 0.1.4 package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24419,9 +24419,8 @@
     },
     "node_modules/yorkie-js-sdk": {
       "version": "0.1.4",
-      "resolved": "git+ssh://git@github.com/yorkie-team/yorkie-js-sdk.git#c9996019142f404d99e8f0f02a4fd43ab03e3709",
-      "integrity": "sha512-ZbgHtiViEKzvmX8z0orYt/dvXTPktvLyb9fY1G7x/siKE7kNsPp61MBTIXRkzrDFdCq8YKW/dS3jZrjSu2SYRA==",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.1.4.tgz",
+      "integrity": "sha512-i2a5PBgvDYfCm/lC7VwBHZiDuxxBCRtvtZlSKOKW3IK+uCrHI7FKsFl04BjeqamyfHZesXZM7V5Ftkcejphsug==",
       "dependencies": {
         "@types/google-protobuf": "^3.7.4",
         "@types/long": "^4.0.1",
@@ -44987,9 +44986,9 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "yorkie-js-sdk": {
-      "version": "git+ssh://git@github.com/yorkie-team/yorkie-js-sdk.git#c9996019142f404d99e8f0f02a4fd43ab03e3709",
-      "integrity": "sha512-ZbgHtiViEKzvmX8z0orYt/dvXTPktvLyb9fY1G7x/siKE7kNsPp61MBTIXRkzrDFdCq8YKW/dS3jZrjSu2SYRA==",
-      "from": "yorkie-js-sdk@0.1.4",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.1.4.tgz",
+      "integrity": "sha512-i2a5PBgvDYfCm/lC7VwBHZiDuxxBCRtvtZlSKOKW3IK+uCrHI7FKsFl04BjeqamyfHZesXZM7V5Ftkcejphsug==",
       "requires": {
         "@types/google-protobuf": "^3.7.4",
         "@types/long": "^4.0.1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

It looks like the old package-lock file needs to be updated.
Even after npm cache clean and reinstallation, the following error occurred.


```
johyeon:yorkie-codepair johyeon-u$ npm i 
npm WARN tarball tarball data for yorkie-js-sdk@git+ssh://git@github.com/yorkie-team/yorkie-js-sdk.git#c9996019142f404d99e8f0f02a4fd43ab03e3709 (sha512-ZbgHtiViEKzvmX8z0orYt/dvXTPktvLyb9fY1G7x/siKE7kNsPp61MBTIXRkzrDFdCq8YKW/dS3jZrjSu2SYRA==) seems to be corrupted. Trying again.
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
