### PR TITLE
Separate concerns from useEffect on drawing board

### DIFF
--- a/design/drawing-canvas.md
+++ b/design/drawing-canvas.md
@@ -14,12 +14,12 @@ Implement drawing tools that can express various shapes such as lines and rectan
 
 ## Proposal Details
 
-![drawing-structure](https://user-images.githubusercontent.com/2059311/116966438-27cd7380-aceb-11eb-8b8d-7dce06ae35ca.png)
+![image](https://user-images.githubusercontent.com/10924072/119370901-cf3d3500-bcf0-11eb-84f6-a67cbb8bbea6.png)
 
 Each role is as follows
 
-- Container
-  - `Container` receives the user's event and passes it to `Worker`, and receives the shape to be drawn on the canvas from `worker` and draws it on the canvas.
+- Board
+  - `Board` receives the user's event and passes it to `Worker`, and receives the shape to be drawn on the canvas from `worker` and draws it on the canvas.
   - lower canvas: `lower canvas` draws shapes that exist in the `yorkie document`.
   - upper canvas: `upper canvas` draws shapes that will be changed by user events.
 - Worker

--- a/src/components/Editor/DrawingBoard/Canvas/Board.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Board.ts
@@ -13,7 +13,7 @@ enum DragStatus {
   Stop,
 }
 
-export default class Container extends EventDispatcher {
+export default class Board extends EventDispatcher {
   private offsetY: number = 0;
 
   private offsetX: number = 0;
@@ -49,7 +49,7 @@ export default class Container extends EventDispatcher {
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
 
-    this.worker = new LineWorker(this.update, this.emit);
+    this.worker = new LineWorker(this.update, this);
 
     touchy(this.upperWrapper.getCanvas(), addEvent, 'mouseup', this.onMouseUp);
     touchy(this.upperWrapper.getCanvas(), addEvent, 'mouseout', this.onMouseUp);
@@ -112,13 +112,13 @@ export default class Container extends EventDispatcher {
     this.worker.flushTask();
 
     if (tool === ToolType.Line) {
-      this.worker = new LineWorker(this.update, this.emit);
+      this.worker = new LineWorker(this.update, this);
     } else if (tool === ToolType.Eraser) {
-      this.worker = new EraserWorker(this.update, this.emit);
+      this.worker = new EraserWorker(this.update, this);
     } else if (tool === ToolType.Rect) {
-      this.worker = new RectWorker(this.update, this.emit);
+      this.worker = new RectWorker(this.update, this);
     } else if (tool === ToolType.Selector) {
-      this.worker = new SelectorWorker(this.update, this.emit);
+      this.worker = new SelectorWorker(this.update, this);
     } else {
       throw new Error(`Undefined tool: ${tool}`);
     }

--- a/src/components/Editor/DrawingBoard/Canvas/Board.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Board.ts
@@ -6,7 +6,7 @@ import CanvasWrapper from './CanvasWrapper';
 import { drawLine } from './line';
 import { drawRect } from './rect';
 import { addEvent, removeEvent, touchy, TouchyEvent } from './dom';
-import { Worker, LineWorker, EraserWorker, RectWorker, SelectorWorker } from './Worker';
+import { Worker, NoneWorker, LineWorker, EraserWorker, RectWorker, SelectorWorker } from './Worker';
 
 enum DragStatus {
   Drag,
@@ -49,7 +49,7 @@ export default class Board extends EventDispatcher {
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
 
-    this.worker = new LineWorker(this.update, this);
+    this.worker = new NoneWorker(this.update, this);
 
     touchy(this.upperWrapper.getCanvas(), addEvent, 'mouseup', this.onMouseUp);
     touchy(this.upperWrapper.getCanvas(), addEvent, 'mouseout', this.onMouseUp);
@@ -122,7 +122,7 @@ export default class Board extends EventDispatcher {
   setTool(tool: ToolType) {
     this.setMouseClass(tool);
 
-    if (this.worker.type === tool || tool === ToolType.None) {
+    if (this.worker.type === tool) {
       return;
     }
 
@@ -136,6 +136,8 @@ export default class Board extends EventDispatcher {
       this.worker = new RectWorker(this.update, this);
     } else if (tool === ToolType.Selector) {
       this.worker = new SelectorWorker(this.update, this);
+    } else if (tool === ToolType.None) {
+      this.worker = new NoneWorker(this.update, this);
     } else {
       throw new Error(`Undefined tool: ${tool}`);
     }

--- a/src/components/Editor/DrawingBoard/Canvas/Board.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Board.ts
@@ -102,6 +102,23 @@ export default class Board extends EventDispatcher {
     this.color = color;
   }
 
+  setWidth(width: number) {
+    this.lowerWrapper.setWidth(width);
+    this.upperWrapper.setWidth(width);
+    this.resize();
+  }
+
+  setHeight(height: number) {
+    this.lowerWrapper.setHeight(height);
+    this.upperWrapper.setHeight(height);
+    this.resize();
+  }
+
+  resize() {
+    this.lowerWrapper.resize();
+    this.upperWrapper.resize();
+  }
+
   setTool(tool: ToolType) {
     this.setMouseClass(tool);
 

--- a/src/components/Editor/DrawingBoard/Canvas/CanvasWrapper.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/CanvasWrapper.ts
@@ -60,10 +60,10 @@ export default class CanvasWrapper {
   resize() {
     const { devicePixelRatio } = window;
     if (devicePixelRatio) {
-      this.setSize(this.canvas.width, this.canvas.height, devicePixelRatio);
+      this.setSize(this.width, this.height, devicePixelRatio);
       this.context.scale(devicePixelRatio, devicePixelRatio);
     } else {
-      this.setSize(this.canvas.width, this.canvas.height);
+      this.setSize(this.width, this.height);
     }
   }
 }

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/EraserWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/EraserWorker.ts
@@ -3,6 +3,7 @@ import { Root, Point, Box } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
 import { createEraserLine, fixEraserPoint } from '../line';
 import Worker from './Worker';
+import Board from '../Board';
 import { compressPoints, checkLineIntersection, isInnerBox, isSelectable } from '../utils';
 import * as scheduler from '../scheduler';
 
@@ -11,16 +12,16 @@ class EraserWorker extends Worker {
 
   update: Function;
 
-  emit: Function;
+  board: Board;
 
   private createID?: TimeTicket;
 
   private eraserBoxSize: number = 24;
 
-  constructor(update: Function, emit: Function) {
+  constructor(update: Function, board: Board) {
     super();
     this.update = update;
-    this.emit = emit;
+    this.board = board;
   }
 
   mousedown(point: Point): void {
@@ -37,8 +38,8 @@ class EraserWorker extends Worker {
     this.createID = timeTicket!;
   }
 
-  mousemove(p: Point) {
-    scheduler.reserveTask(p, (tasks: Array<scheduler.Task>) => {
+  mousemove(point: Point) {
+    scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
       const points = compressPoints(tasks);
 
       if (tasks.length < 2) {
@@ -97,7 +98,7 @@ class EraserWorker extends Worker {
         findAndRemoveShape(pointStart, pointEnd);
         lastShape.points = [pointStart, pointEnd];
 
-        this.emit('renderAll', root.shapes);
+        this.board.drawAll(root.shapes);
       });
     });
   }
@@ -115,7 +116,7 @@ class EraserWorker extends Worker {
       }
 
       this.deleteByID(root, this.createID);
-      this.emit('renderAll', root.shapes);
+      this.board.drawAll(root.shapes);
     });
   }
 

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/EraserWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/EraserWorker.ts
@@ -1,9 +1,9 @@
 import { TimeTicket } from 'yorkie-js-sdk';
 import { Root, Point, Box } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
+import Board from 'components/Editor/DrawingBoard/Canvas/Board';
 import { createEraserLine, fixEraserPoint } from '../line';
 import Worker from './Worker';
-import Board from '../Board';
 import { compressPoints, checkLineIntersection, isInnerBox, isSelectable } from '../utils';
 import * as scheduler from '../scheduler';
 

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
@@ -1,9 +1,9 @@
 import { TimeTicket } from 'yorkie-js-sdk';
 import { Root, Point } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
+import Board from 'components/Editor/DrawingBoard/Canvas/Board';
 import { LineOption, createLine } from '../line';
 import Worker from './Worker';
-import Board from '../Board';
 import { compressPoints } from '../utils';
 import * as scheduler from '../scheduler';
 

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/LineWorker.ts
@@ -3,6 +3,7 @@ import { Root, Point } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
 import { LineOption, createLine } from '../line';
 import Worker from './Worker';
+import Board from '../Board';
 import { compressPoints } from '../utils';
 import * as scheduler from '../scheduler';
 
@@ -11,14 +12,14 @@ class LineWorker extends Worker {
 
   update: Function;
 
-  emit: Function;
+  board: Board;
 
   private createID?: TimeTicket;
 
-  constructor(update: Function, emit: Function) {
+  constructor(update: Function, board: Board) {
     super();
     this.update = update;
-    this.emit = emit;
+    this.board = board;
   }
 
   mousedown(point: Point, options: LineOption): void {
@@ -35,8 +36,8 @@ class LineWorker extends Worker {
     this.createID = timeTicket!;
   }
 
-  mousemove(p: Point) {
-    scheduler.reserveTask(p, (tasks: Array<scheduler.Task>) => {
+  mousemove(point: Point) {
+    scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
       const points = compressPoints(tasks);
 
       if (tasks.length < 2) {
@@ -50,7 +51,7 @@ class LineWorker extends Worker {
         }
 
         lastShape.points.push(...points);
-        this.emit('renderAll', root.shapes);
+        this.board.drawAll(root.shapes);
       });
     });
   }
@@ -77,7 +78,7 @@ class LineWorker extends Worker {
         this.deleteByID(root, this.createID!);
       }
 
-      this.emit('renderAll', root.shapes);
+      this.board.drawAll(root.shapes);
     });
   }
 }

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/NoneWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/NoneWorker.ts
@@ -1,0 +1,27 @@
+import Board from 'components/Editor/DrawingBoard/Canvas/Board';
+import { ToolType } from 'features/boardSlices';
+import Worker from './Worker';
+
+class NoneWorker extends Worker {
+  type = ToolType.None;
+
+  update: Function;
+
+  board: Board;
+
+  constructor(update: Function, board: Board) {
+    super();
+    this.update = update;
+    this.board = board;
+  }
+
+  mousedown() { }
+
+  mousemove() { }
+
+  mouseup() { }
+
+  flushTask() { }
+}
+
+export default NoneWorker;

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/RectWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/RectWorker.ts
@@ -3,6 +3,7 @@ import { Root, Point, Rect } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
 import { createRect, adjustRectBox } from '../rect';
 import Worker from './Worker';
+import Board from '../Board';
 import * as scheduler from '../scheduler';
 
 class RectWorker extends Worker {
@@ -10,14 +11,14 @@ class RectWorker extends Worker {
 
   update: Function;
 
-  emit: Function;
+  board: Board;
 
   private createID?: TimeTicket;
 
-  constructor(update: Function, emit: Function) {
+  constructor(update: Function, board: Board) {
     super();
     this.update = update;
-    this.emit = emit;
+    this.board = board;
   }
 
   mousedown(point: Point): void {
@@ -34,19 +35,19 @@ class RectWorker extends Worker {
     this.createID = timeTicket!;
   }
 
-  mousemove(p: Point) {
-    scheduler.reserveTask(p, (tasks: Array<scheduler.Task>) => {
+  mousemove(point: Point) {
+    scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
       if (tasks.length < 2) {
         return;
       }
 
       this.update((root: Root) => {
-        const point = tasks[tasks.length - 1];
+        const lastPoint = tasks[tasks.length - 1];
         const lastShape = this.getElementByID(root, this.createID!) as Rect;
-        const box = adjustRectBox(lastShape, point);
+        const box = adjustRectBox(lastShape, lastPoint);
         lastShape.box = box;
 
-        this.emit('renderAll', root.shapes);
+        this.board.drawAll(root.shapes);
       });
     });
   }

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/RectWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/RectWorker.ts
@@ -1,9 +1,9 @@
 import { TimeTicket } from 'yorkie-js-sdk';
 import { Root, Point, Rect } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
+import Board from 'components/Editor/DrawingBoard/Canvas/Board';
 import { createRect, adjustRectBox } from '../rect';
 import Worker from './Worker';
-import Board from '../Board';
 import * as scheduler from '../scheduler';
 
 class RectWorker extends Worker {

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/SelectorWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/SelectorWorker.ts
@@ -1,8 +1,8 @@
 import { Root, Point, Shape } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
+import Board from 'components/Editor/DrawingBoard/Canvas/Board';
 import { isInnerBox, cloneBox, isSelectable } from '../utils';
 import Worker from './Worker';
-import Board from '../Board';
 import * as scheduler from '../scheduler';
 
 class SelectorWorker extends Worker {

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/SelectorWorker.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/SelectorWorker.ts
@@ -2,6 +2,7 @@ import { Root, Point, Shape } from 'features/docSlices';
 import { ToolType } from 'features/boardSlices';
 import { isInnerBox, cloneBox, isSelectable } from '../utils';
 import Worker from './Worker';
+import Board from '../Board';
 import * as scheduler from '../scheduler';
 
 class SelectorWorker extends Worker {
@@ -9,14 +10,14 @@ class SelectorWorker extends Worker {
 
   update: Function;
 
-  emit: Function;
+  board: Board;
 
   private selectedShape?: { shape: Shape; point: Point };
 
-  constructor(update: Function, emit: Function) {
+  constructor(update: Function, board: Board) {
     super();
     this.update = update;
-    this.emit = emit;
+    this.board = board;
   }
 
   mousedown(point: Point): void {
@@ -32,8 +33,8 @@ class SelectorWorker extends Worker {
     this.selectedShape = undefined;
   }
 
-  mousemove(p: Point) {
-    scheduler.reserveTask(p, (tasks: Array<scheduler.Task>) => {
+  mousemove(point: Point) {
+    scheduler.reserveTask(point, (tasks: Array<scheduler.Task>) => {
       if (tasks.length < 2) {
         return;
       }
@@ -65,7 +66,7 @@ class SelectorWorker extends Worker {
             x: lastShape.points[0].x + offsetX,
           };
         }
-        this.emit('renderAll', root.shapes);
+        this.board.drawAll(root.shapes);
       });
     });
   }

--- a/src/components/Editor/DrawingBoard/Canvas/Worker/index.ts
+++ b/src/components/Editor/DrawingBoard/Canvas/Worker/index.ts
@@ -3,3 +3,4 @@ export { default as LineWorker } from './LineWorker';
 export { default as RectWorker } from './RectWorker';
 export { default as EraserWorker } from './EraserWorker';
 export { default as SelectorWorker } from './SelectorWorker';
+export { default as NoneWorker } from './NoneWorker';

--- a/src/components/Editor/DrawingBoard/index.tsx
+++ b/src/components/Editor/DrawingBoard/index.tsx
@@ -4,12 +4,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { AppState } from 'app/rootReducer';
 import { ToolType, setTool } from 'features/boardSlices';
 
-import Container from './Canvas/Container';
+import Board from './Canvas/Board';
 import './index.scss';
 
 export default function DrawingBoard({ width, height }: { width: number; height: number }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const containerRef = useRef<Container | null>(null);
+  const boardRef = useRef<Board | null>(null);
   const dispatch = useDispatch();
   const doc = useSelector((state: AppState) => state.docState.doc);
   const tool = useSelector((state: AppState) => state.boardState.tool);
@@ -23,11 +23,11 @@ export default function DrawingBoard({ width, height }: { width: number; height:
     canvasRef.current.width = width;
     canvasRef.current.height = height;
 
-    const container = new Container(canvasRef.current, doc.update.bind(doc));
-    containerRef.current = container;
-    containerRef.current.setTool(tool);
-    containerRef.current.setColor(color);
-    containerRef.current.drawAll(doc.getRoot().shapes);
+    const board = new Board(canvasRef.current, doc.update.bind(doc));
+    boardRef.current = board;
+    boardRef.current.setTool(tool);
+    boardRef.current.setColor(color);
+    boardRef.current.drawAll(doc.getRoot().shapes);
 
     const handleMouseup = () => {
       if (tool === ToolType.Rect) {
@@ -35,11 +35,11 @@ export default function DrawingBoard({ width, height }: { width: number; height:
       }
     };
 
-    containerRef.current.addEventListener('mouseup', handleMouseup);
+    boardRef.current.addEventListener('mouseup', handleMouseup);
 
     return () => {
-      containerRef.current?.removeEventListener('mouseup', handleMouseup);
-      container.destroy();
+      boardRef.current?.removeEventListener('mouseup', handleMouseup);
+      board.destroy();
     };
   }, [width, height, doc, tool, color]);
 
@@ -50,7 +50,7 @@ export default function DrawingBoard({ width, height }: { width: number; height:
 
     const unsubscribe = doc.subscribe((event) => {
       if (event.type === 'remote-change') {
-        containerRef.current?.drawAll(doc.getRoot().shapes);
+        boardRef.current?.drawAll(doc.getRoot().shapes);
       }
     });
 
@@ -60,7 +60,7 @@ export default function DrawingBoard({ width, height }: { width: number; height:
   }, [doc]);
 
   useEffect(() => {
-    containerRef.current?.setTool(tool);
+    boardRef.current?.setTool(tool);
   }, [doc, tool]);
 
   return <canvas ref={canvasRef} />;

--- a/src/components/Editor/DrawingBoard/index.tsx
+++ b/src/components/Editor/DrawingBoard/index.tsx
@@ -16,32 +16,16 @@ export default function DrawingBoard({ width, height }: { width: number; height:
   const color = useSelector((state: AppState) => state.boardState.color);
 
   useEffect(() => {
-    if (!canvasRef.current || !doc) {
+    if (!canvasRef.current) {
       return () => {};
     }
-
-    canvasRef.current.width = width;
-    canvasRef.current.height = height;
-
-    const board = new Board(canvasRef.current, doc.update.bind(doc));
+    const board = new Board(canvasRef.current, doc!.update.bind(doc));
     boardRef.current = board;
-    boardRef.current.setTool(tool);
-    boardRef.current.setColor(color);
-    boardRef.current.drawAll(doc.getRoot().shapes);
-
-    const handleMouseup = () => {
-      if (tool === ToolType.Rect) {
-        dispatch(setTool(ToolType.Selector));
-      }
-    };
-
-    boardRef.current.addEventListener('mouseup', handleMouseup);
 
     return () => {
-      boardRef.current?.removeEventListener('mouseup', handleMouseup);
       board.destroy();
     };
-  }, [width, height, doc, tool, color]);
+  }, [doc]);
 
   useEffect(() => {
     if (!doc) {
@@ -60,8 +44,35 @@ export default function DrawingBoard({ width, height }: { width: number; height:
   }, [doc]);
 
   useEffect(() => {
+    const handleMouseup = () => {
+      if (tool === ToolType.Rect) {
+        dispatch(setTool(ToolType.Selector));
+      }
+    };
+
+    boardRef.current?.addEventListener('mouseup', handleMouseup);
+    return () => {
+      boardRef.current?.removeEventListener('mouseup', handleMouseup);
+    };
+  }, [doc, tool]);
+
+  useEffect(() => {
+    if (!canvasRef.current) {
+      return;
+    }
+
+    boardRef.current?.setWidth(width);
+    boardRef.current?.setHeight(height);
+    boardRef.current?.drawAll(doc!.getRoot().shapes);
+  }, [doc, width, height]);
+
+  useEffect(() => {
     boardRef.current?.setTool(tool);
   }, [doc, tool]);
+
+  useEffect(() => {
+    boardRef.current?.setColor(color);
+  }, [doc, color]);
 
   return <canvas ref={canvasRef} />;
 }

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { useSelector } from 'react-redux';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 
-import { AppState } from 'app/rootReducer';
 import CodeEditor from 'components/Editor/CodeEditor';
 import DrawingBoard from 'components/Editor/DrawingBoard';
 import Sidebar from 'components/Editor/Sidebar';
@@ -45,8 +43,6 @@ const useStyles = makeStyles(() =>
 
 export default function Editor({ tool }: EditorProps) {
   const classes = useStyles(tool);
-  const doc = useSelector((state: AppState) => state.docState.doc);
-  const client = useSelector((state: AppState) => state.docState.client);
 
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
@@ -81,16 +77,12 @@ export default function Editor({ tool }: EditorProps) {
   return (
     <div className={classes.root} onClick={onClickEditor} aria-hidden="true">
       <div className={classes.editor} ref={divRef}>
-        {client && doc && (
-          <>
-            <div className={classes.codeEditor}>
-              <CodeEditor forwardedRef={codeEditorRef} />
-            </div>
-            <div className={classes.canvas}>
-              <DrawingBoard width={width} height={height} />
-            </div>
-          </>
-        )}
+        <div className={classes.codeEditor}>
+          <CodeEditor forwardedRef={codeEditorRef} />
+        </div>
+        <div className={classes.canvas}>
+          <DrawingBoard width={width} height={height} />
+        </div>
       </div>
       <Sidebar />
     </div>

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 
+import { AppState } from 'app/rootReducer';
 import CodeEditor from 'components/Editor/CodeEditor';
 import DrawingBoard from 'components/Editor/DrawingBoard';
 import Sidebar from 'components/Editor/Sidebar';
@@ -43,6 +45,8 @@ const useStyles = makeStyles(() =>
 
 export default function Editor({ tool }: EditorProps) {
   const classes = useStyles(tool);
+  const doc = useSelector((state: AppState) => state.docState.doc);
+  const client = useSelector((state: AppState) => state.docState.client);
 
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
@@ -77,12 +81,16 @@ export default function Editor({ tool }: EditorProps) {
   return (
     <div className={classes.root} onClick={onClickEditor} aria-hidden="true">
       <div className={classes.editor} ref={divRef}>
-        <div className={classes.codeEditor}>
-          <CodeEditor forwardedRef={codeEditorRef} />
-        </div>
-        <div className={classes.canvas}>
-          <DrawingBoard width={width} height={height} />
-        </div>
+        {client && doc && (
+          <>
+            <div className={classes.codeEditor}>
+              <CodeEditor forwardedRef={codeEditorRef} />
+            </div>
+            <div className={classes.canvas}>
+              <DrawingBoard width={width} height={height} />
+            </div>
+          </>
+        )}
       </div>
       <Sidebar />
     </div>

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -128,7 +128,7 @@ export default function (props: { docKey: string }) {
     );
   }
 
-  if (loading) {
+  if (loading || !client || !doc) {
     return (
       <Box className={classes.loading}>
         <CircularProgress color="inherit" />

--- a/src/features/docSlices.ts
+++ b/src/features/docSlices.ts
@@ -71,7 +71,7 @@ export interface Shapes {
 
 //  TODO(ppeeou) refer to yorkie-sdk-js JSONObject
 export interface Root {
-  shapes: Shapes;
+  shapes: Shapes & Array<Shape>;
 }
 
 export enum DocStatus {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Separate concerns from `useEffect`

Since Drawing board is updating all in one `useEffect`, a new canvas is created even if the `tool` is changed.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
