### PR TITLE
Bugfix when mouse out strange work on canvas

### DIFF
--- a/webapp/src/components/Editor/DrawingBoard/Canvas/Board.ts
+++ b/webapp/src/components/Editor/DrawingBoard/Canvas/Board.ts
@@ -46,13 +46,14 @@ export default class Board extends EventDispatcher {
     this.emit = this.emit.bind(this);
     this.drawAll = this.drawAll.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
+    this.onMouseOut = this.onMouseOut.bind(this);
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
 
     this.worker = new NoneWorker(this.update, this);
 
     touchy(this.upperWrapper.getCanvas(), addEvent, 'mouseup', this.onMouseUp);
-    touchy(this.upperWrapper.getCanvas(), addEvent, 'mouseout', this.onMouseUp);
+    touchy(this.upperWrapper.getCanvas(), addEvent, 'mouseout', this.onMouseOut);
     touchy(this.upperWrapper.getCanvas(), addEvent, 'mousedown', this.onMouseDown);
 
     this.addEventListener('renderAll', this.drawAll);
@@ -60,7 +61,7 @@ export default class Board extends EventDispatcher {
 
   destroy() {
     touchy(this.upperWrapper.getCanvas(), removeEvent, 'mouseup', this.onMouseUp);
-    touchy(this.upperWrapper.getCanvas(), removeEvent, 'mouseout', this.onMouseUp);
+    touchy(this.upperWrapper.getCanvas(), removeEvent, 'mouseout', this.onMouseOut);
     touchy(this.upperWrapper.getCanvas(), removeEvent, 'mousedown', this.onMouseDown);
 
     this.destroyUpperCanvas();
@@ -202,6 +203,11 @@ export default class Board extends EventDispatcher {
 
     this.worker.mouseup();
     this.emit('mouseup');
+  }
+
+  onMouseOut() {
+    this.dragStatus = DragStatus.Stop;
+    this.worker.flushTask();
   }
 
   isOutside(point: Point): boolean {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

If mouseup action is performed on mouseout event, unwanted action may occur as shown below.
We didn't create a rectangle, but the selected tool changes.

![save](https://user-images.githubusercontent.com/10924072/127748029-10cede5b-1f12-4441-af8a-b29af79c5d6a.gif)

Distinguish between mouseout event actions and mouseup event actions.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
