### PR TITLE
Add comments to help configure envoy and yorkie containers

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,13 @@ services:
       - '9901:9901'
     depends_on:
       - yorkie
+    # If you're using Mac or Windows, this special domain name("host.docker.internal" which makes containers able to connect to the host)
+    # is supported by default.
+    # But if you're using Linux and want an envoy container to communicate with the host,
+    # it may help to define "host.docker.internal" in extra_hosts. 
+    # (Actually, other hostnames are available, but in that case you should update clusters[].host configurations of envoy.yaml)
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway"
   yorkie:
     volumes:
     - ./yorkie.json:/app/yorkie.json

--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -46,4 +46,5 @@ static_resources:
     # When you want envoy container to communicate with your host machine, you should set as the following
     # - Windows/Mac: Input host.docker.internal
     # - Linux: an IP address of the host machine or docker-0 interface or some addresses defined in extra hosts of docker-compose.yml
+    # you can simply use the yorkie container name(e.g. yorkie) in docker-compose whatever your OS is.
     hosts: [{ socket_address: { address: host.docker.internal, port_value: 11101 }}]

--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -42,5 +42,8 @@ static_resources:
     type: logical_dns
     http2_protocol_options: {}
     lb_policy: round_robin
-    # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
+    # Input the address which envoy can connect to as a yorkie server.
+    # When you want envoy container to communicate with your host machine, you should set as the following
+    # - Windows/Mac: Input host.docker.internal
+    # - Linux: an internal IP address of the host machine or some addresses defined in extra hosts of docker-compose.yml
     hosts: [{ socket_address: { address: host.docker.internal, port_value: 11101 }}]

--- a/docker/envoy.yaml
+++ b/docker/envoy.yaml
@@ -45,5 +45,5 @@ static_resources:
     # Input the address which envoy can connect to as a yorkie server.
     # When you want envoy container to communicate with your host machine, you should set as the following
     # - Windows/Mac: Input host.docker.internal
-    # - Linux: an internal IP address of the host machine or some addresses defined in extra hosts of docker-compose.yml
+    # - Linux: an IP address of the host machine or docker-0 interface or some addresses defined in extra hosts of docker-compose.yml
     hosts: [{ socket_address: { address: host.docker.internal, port_value: 11101 }}]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

https://github.com/yorkie-team/yorkie-codepair/blob/bb88f445b1a17b7a498b399712cd7bfcf9dcc794/docker/envoy.yaml#L45

It doesn't work setting localhost to connect to a yorkie server on Linux. Although we binded some ports(host:11101 <-> yorkie:11101), envoy container can't connect to the yorkie server with localhost by default on Linux. If you want this, you should define a hostname for `host-gateway` in `extra_hosts` of `docker-compose.yml`.
After that, you can access host by the extra hostname you configured.
Please take a look at the example.
```bash
# In an envoy container

root@80d7d00775cd:/# cat /etc/hosts
127.0.0.1       localhost
::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
172.17.0.1      host.docker.internal <- You can access host by this.
172.18.0.4      80d7d00775cd

# ping does work by host.docker.internal
root@80d7d00775cd:/# ping host.docker.internal
PING host.docker.internal (172.17.0.1) 56(84) bytes of data.
64 bytes from host.docker.internal (172.17.0.1): icmp_seq=1 ttl=64 time=0.109 m

# or you can use the exact host ip without configuring extra hosts.
# supposing my ip is 192.168.219.166
root@80d7d00775cd:/# ping 192.168.219.166
PING 192.168.219.166 (192.168.219.166) 56(84) bytes of data.
64 bytes from 192.168.219.166: icmp_seq=1 ttl=64 time=0.060 ms
```

#### Any background context you want to provide?

* Win/Mac can you host.docker.internal by default but Linux cannot - [How to access host port from docker container](https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container)
  > When running Docker natively on Linux, you can access host services using the IP address of the docker0 interface

  It may be simple setting `172.17.0.1` which is the default `docker-0` interface IP, but I think the exact IP address may differ depending on the configurations of docker.
#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
