### PR TITLE
Change drag content background color opacity by rgba

### DIFF
--- a/webapp/src/components/Editor/CodeEditor/Cursor.ts
+++ b/webapp/src/components/Editor/CodeEditor/Cursor.ts
@@ -66,11 +66,10 @@ export default class Cursor {
   updateLine(cm: CodeMirror.Editor, fromPos: CodeMirror.Position, toPos: CodeMirror.Position) {
     this.removeLine();
     this.status = CursorStatus.Activated;
-    // Change HEX to RGBA
+    // Apply transparency to the background of selection.
     const redColor = parseInt(this.color.slice(1, 3), 16);
     const greenColor = parseInt(this.color.slice(3, 5), 16);
     const blueColor = parseInt(this.color.slice(5, 7), 16);
-    // opacity apply by rgba, not opacity.
     const backgroundColor = `rgba(${redColor}, ${greenColor}, ${blueColor}, 0.15)`;
 
     this.lineMarker = cm.getDoc().markText(fromPos, toPos, {

--- a/webapp/src/components/Editor/CodeEditor/Cursor.ts
+++ b/webapp/src/components/Editor/CodeEditor/Cursor.ts
@@ -66,9 +66,15 @@ export default class Cursor {
   updateLine(cm: CodeMirror.Editor, fromPos: CodeMirror.Position, toPos: CodeMirror.Position) {
     this.removeLine();
     this.status = CursorStatus.Activated;
+    // Change HEX to RGBA
+    const redColor = parseInt(this.color.slice(1, 3), 16);
+    const greenColor = parseInt(this.color.slice(3, 5), 16);
+    const blueColor = parseInt(this.color.slice(5, 7), 16);
+    // opacity apply by rgba, not opacity.
+    const backgroundColor = `rgba(${redColor}, ${greenColor}, ${blueColor}, 0.15)`;
 
     this.lineMarker = cm.getDoc().markText(fromPos, toPos, {
-      css: `background-color : ${this.color}; opacity:0.7`,
+      css: `background-color : ${backgroundColor};`,
     });
   }
 


### PR DESCRIPTION
Change drag content background color opacity by rgba, not by opacity.

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

![image](https://user-images.githubusercontent.com/47362439/129439174-dac53599-a524-4d91-bacd-cfcfa9f78e06.png)

Change drag content background color opacity by rgba, not by opacity. So It made the letters recognizable.

#### Any background context you want to provide?

metaData's color is expressed by hex. So I changed it rgba and lower the opacity.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #127

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
