### PR TITLE
Apply bezier curves to line drawing

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-jsx-a11y": "^6.4.1",
         "eslint-plugin-react": "^7.21.5",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "fit-curve": "^0.2.0",
         "husky": "^4.2.5",
         "invert-color": "^2.0.0",
         "lint-staged": "^10.3.0",
@@ -10616,6 +10617,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fit-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fit-curve/-/fit-curve-0.2.0.tgz",
+      "integrity": "sha512-op7ofeL13getbqL5J5ACeNxTlLWzusn4/jjEjSVA1sS7PfXWumdtNITvLuTjSobis+jZzMil2rsJ3Vhw7OxQyQ=="
     },
     "node_modules/flat-cache": {
       "version": "2.0.1",
@@ -34294,6 +34300,11 @@
         "semver-regex": "^2.0.0"
       }
     },
+    "fit-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fit-curve/-/fit-curve-0.2.0.tgz",
+      "integrity": "sha512-op7ofeL13getbqL5J5ACeNxTlLWzusn4/jjEjSVA1sS7PfXWumdtNITvLuTjSobis+jZzMil2rsJ3Vhw7OxQyQ=="
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -46363,7 +46374,7 @@
     },
     "yorkie-js-sdk": {
       "version": "git+ssh://git@github.com/yorkie-team/yorkie-js-sdk.git#1c4ad2b2ed9cb2504d673f660c034f0de4390bcd",
-      "from": "yorkie-js-sdk@https://github.com/yorkie-team/yorkie-js-sdk#1c4ad2b",
+      "from": "yorkie-js-sdk@github:yorkie-team/yorkie-js-sdk#1c4ad2b",
       "requires": {
         "@types/google-protobuf": "^3.7.4",
         "@types/long": "^4.0.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "fit-curve": "^0.2.0",
     "husky": "^4.2.5",
     "invert-color": "^2.0.0",
     "lint-staged": "^10.3.0",

--- a/webapp/src/components/Editor/DrawingBoard/Canvas/Board.ts
+++ b/webapp/src/components/Editor/DrawingBoard/Canvas/Board.ts
@@ -3,7 +3,7 @@ import { Point, Shape } from 'features/docSlices';
 import EventDispatcher from 'utils/eventDispatcher';
 
 import CanvasWrapper from './CanvasWrapper';
-import { drawLine } from './line';
+import { drawLine, drawEraser } from './line';
 import { drawRect } from './rect';
 import { addEvent, removeEvent, touchy, TouchyEvent } from './dom';
 import { Worker, NoneWorker, LineWorker, EraserWorker, RectWorker, SelectorWorker } from './Worker';
@@ -228,7 +228,7 @@ export default class Board extends EventDispatcher {
       if (shape.type === 'line') {
         drawLine(wrapper.getContext(), shape);
       } else if (shape.type === 'eraser') {
-        drawLine(wrapper.getContext(), shape);
+        drawEraser(wrapper.getContext(), shape);
       } else if (shape.type === 'rect') {
         drawRect(wrapper.getContext(), shape);
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Apply bezier curves to line drawing.

Before:

<img width="474" alt="Screen Shot 2021-10-20 at 11 51 05 AM" src="https://user-images.githubusercontent.com/2059311/138020228-131649d9-a3a5-43a5-85e4-97dfc5b3178d.png">

After:
<img width="553" alt="Screen Shot 2021-10-20 at 11 51 10 AM" src="https://user-images.githubusercontent.com/2059311/138020252-7f9648d0-aa57-48a8-84b8-47cc7201b6de.png">


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #65

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
